### PR TITLE
CMCP is about "extensional" type theory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ Resources for the proposed type theory study group. Please discuss/contribute.
 * The Simply Typed Lambda Calculus / Progress and Preservation
 * Propositions as Types / Proofs as Programs
 * System F / Parametricity
-* Martin-Löf's Intensional Type Theory / Constructive Mathematics and Computer Programming
+* Martin-Löf's Extensional Type Theory / Constructive Mathematics and Computer Programming
 * Identity Types / Proofs of Equality in Martin-Löf's Intensional Type Theory
-* Martin-Löf's Original Extensional Type Theory / Undecidability of the Equality Reflection Rule
 * Topological Spaces as Types / Points as Programs
 * Intensional Proofs of Equality as Paths between Spaces
 * Proofs of Equality of Equalities as Synthetic Homotopies


### PR DESCRIPTION
Collapsed two ETT-related items into one as well; also, equality reflection should be discussed in the context of the explanation of elimination rules (i.e. how does one show that an elimination rule is valid wrt. the semantics), since MLTT 1979 is undecidable whether or not equality reflection is included.
