### PR TITLE
clarify some logical framework issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Resources for the proposed type theory study group. Please discuss/contribute.
 * Homotopy Type Theory / Higher Inductive Types / Univalence
 * Canonicity for Homotopy Type Theory / Current Issues
 * Special Cases of Homotopy Type Theory with Canonicity / Cubical Type Theories
-* Martin-Löf's Logical Framework / "Mechanizing Metatheory in a Logical Framework"
+* Martin-Löf's (Equational) Logical Framework and the Monomorphic Theory of Sets
+* The Edinburgh Logical Framework / "Mechanizing Metatheory in a Logical Framework"
 * Categorical Semantics of Type Theories / Connection to Category Theory Study Group


### PR DESCRIPTION
Martin-Löf's logical framework was developed concurrently with the Edinburgh logical framework, but is quite different. The main difference is that MLLF allows equations (and so is like a framework for algebraic theories), whereas ELF does not.
