### PR TITLE
Add Google Hangouts link to Next Meeting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Studying type theory is to understand the techniques of types and can be a found
 ##### Next meeting
 
 - When: November 13th, 6 pm EST
-- Where: Google Hangouts
+- Where: [Google Hangouts](https://plus.google.com/hangouts/_/jspha.com/me?authuser=0)
 - Material: Ch 1 and 2 of PFPL
 - Discussion Leaders: Joseph Abrahamson, Danny Gratzer, and Craig Stuntz
 


### PR DESCRIPTION
Taken from this post: https://groups.google.com/forum/#!topic/type-theory-study-group/j8r4Vo7Ww28
